### PR TITLE
feat: typed response

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -36,12 +36,12 @@ func (d Deck) FullHelp() [][]key.Binding {
 }
 
 func (c Card) ShortHelp() []key.Binding {
-	return []key.Binding{cardKeyMap.Open, cardKeyMap.Back}
+	return []key.Binding{cardKeyMap.Open, cardKeyMap.Fill, cardKeyMap.Back}
 }
 
 func (c Card) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{cardKeyMap.Open, cardKeyMap.Back},
+		{},
 	}
 }
 
@@ -63,6 +63,7 @@ type keyMap struct {
 	Again  key.Binding
 	Search key.Binding
 	Undo   key.Binding
+	Fill   key.Binding
 
 	ShowFullHelp  key.Binding
 	CloseFullHelp key.Binding
@@ -72,6 +73,10 @@ var cardKeyMap = keyMap{
 	Back: key.NewBinding(
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "exit review"),
+	),
+	Fill: key.NewBinding(
+		key.WithKeys("i"),
+		key.WithHelp("i", "type response"),
 	),
 	Open: key.NewBinding(
 		key.WithKeys("o"),
@@ -96,6 +101,10 @@ func DeckKeyMap() keyMap {
 		Open: key.NewBinding(
 			key.WithKeys("o"),
 			key.WithHelp("o", "show back"),
+		),
+		Fill: key.NewBinding(
+			key.WithKeys("i"),
+			key.WithHelp("i", "type response"),
 		),
 		Again: key.NewBinding(
 			key.WithKeys("1"),

--- a/style.go
+++ b/style.go
@@ -27,11 +27,13 @@ var (
 	// deck.go
 	cardStyle = lipgloss.NewStyle().MarginTop(screenHeight / 10).MarginLeft(3 * screenWidth / 10).Width(2 * screenWidth / 5).
 			Height(screenHeight / 5).Border(lipgloss.RoundedBorder()).Align(lipgloss.Center)
-	listStyle       = lipgloss.NewStyle().Align(lipgloss.Left).MarginLeft((screenWidth - 60) / 2).Padding(2)
-	questionStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10")).MarginTop(2)
-	answerStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).MarginTop(4).MarginBottom(4)
-	deckFooterStyle = lipgloss.NewStyle().MarginTop(10)
-	progressStyle   = lipgloss.NewStyle().MarginTop(1).Render
+	listStyle           = lipgloss.NewStyle().Align(lipgloss.Left).MarginLeft((screenWidth - 60) / 2).Padding(2)
+	questionStyle       = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("10")).MarginTop(2)
+	answerStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).MarginTop(4).MarginBottom(4)
+	deckFooterStyle     = lipgloss.NewStyle().MarginTop(10)
+	progressStyle       = lipgloss.NewStyle().MarginTop(1).Render
+	promptFooterStyle   = lipgloss.NewStyle().MarginTop(10).Width(40)
+	promptCompleteStyle = lipgloss.NewStyle().Margin(0).Width(40)
 
 	// form.go
 	formTitleStyle  = lipgloss.NewStyle().Background(lipgloss.Color("62")).Foreground(lipgloss.Color("230")).Padding(0, 1).MarginTop(1).Render

--- a/util.go
+++ b/util.go
@@ -68,6 +68,13 @@ func initInput() {
 	currUser.input.CharLimit = 20
 }
 
+func (d *Deck) initCardInput() {
+	d.fillInResponse = textinput.New()
+	d.fillInResponse.Placeholder = ""
+	d.fillInResponse.PromptStyle = focusedStyle
+	d.fillInResponse.CharLimit = 20
+}
+
 func saveAll() {
 	saveDecks()
 	for _, deck := range currUser.decks {


### PR DESCRIPTION
Add a typed response (#1) option when reviewing cards. Currently, since the response is binary, either correct or incorrect, we're assigning `Easy` and `Again` respectively within the SM2 spaced repetition algorithm.